### PR TITLE
Min sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ jdk:
 android:
   components:
 
-    - build-tools-21.1.1
-    - android-21
+    - build-tools-22.0.1
+    - android-22
     - extra-android-support
     - extra-google-google_play_services
     - extra-google-m2repository

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ PicassoPalette
 
 In your module [![Download](https://api.bintray.com/packages/florent37/maven/PicassoPalette/images/download.svg)](https://bintray.com/florent37/maven/PicassoPalette/_latestVersion)
 ```groovy
+repositories {
+    jcenter()
+}
+
 compile 'com.github.florent37:picassopalette:1.0.2@aar'
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,13 +3,14 @@
 buildscript {
     repositories {
         jcenter()
+        mavenCentral()
         maven {
             url  "http://dl.bintray.com/jfrog/jfrog-jars"
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.2'
-        classpath 'com.github.dcendents:android-maven-plugin:1.2'
+        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.1"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Mon Apr 18 10:34:44 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/picassopalette/build.gradle
+++ b/picassopalette/build.gradle
@@ -6,10 +6,10 @@ version = "1.0.2"
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "21.1.2"
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 11
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"
@@ -24,8 +24,8 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:palette-v7:22.2.0'
-    compile 'com.android.support:support-v4:22.2.0'
+    compile 'com.android.support:palette-v7:22.2.1'
+    compile 'com.android.support:support-v4:22.2.1'
     compile 'com.squareup.picasso:picasso:2.5.2'
 }
 

--- a/picassopalette/build.gradle
+++ b/picassopalette/build.gradle
@@ -9,7 +9,7 @@ android {
     buildToolsVersion "22.0.1"
 
     defaultConfig {
-        minSdkVersion 11
+        minSdkVersion 8
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"

--- a/picassopalette/src/main/java/com/github/florent37/picassopalette/BitmapPalette.java
+++ b/picassopalette/src/main/java/com/github/florent37/picassopalette/BitmapPalette.java
@@ -2,10 +2,10 @@ package com.github.florent37.picassopalette;
 
 import android.graphics.Bitmap;
 import android.support.annotation.IntDef;
+import android.support.v4.util.LruCache;
 import android.support.v4.util.Pair;
 import android.support.v7.graphics.Palette;
 import android.util.Log;
-import android.util.LruCache;
 import android.view.View;
 import android.widget.TextView;
 

--- a/picassopalette/src/main/java/com/github/florent37/picassopalette/PaletteTarget.java
+++ b/picassopalette/src/main/java/com/github/florent37/picassopalette/PaletteTarget.java
@@ -21,7 +21,7 @@ public class PaletteTarget {
         this.paletteProfile = paletteProfile;
     }
 
-    public void clear(){
+    public void clear() {
         targetsBackground.clear();
         targetsText.clear();
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.github.florent37.picassopalette"
-        minSdkVersion 11
+        minSdkVersion 8
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
         applicationId "com.github.florent37.picassopalette"
-        minSdkVersion 14
-        targetSdkVersion 21
+        minSdkVersion 11
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
     }
@@ -21,7 +21,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.1.1'
+    compile 'com.android.support:appcompat-v7:22.2.1'
     compile 'com.squareup.picasso:picasso:2.5.2'
 
     compile project(":picassopalette")


### PR DESCRIPTION
minSdk was currently 14. Is there a reason for that ?

After quick investigation, by using support LruCache, it is now possible to lower minSdk target. I have set it to 8.

I have also updated gradle tools & version for newer environment.